### PR TITLE
feat: improve matching

### DIFF
--- a/configuration.revanced.json
+++ b/configuration.revanced.json
@@ -318,7 +318,7 @@
 					954147049832603748
 				],
 				"match": [
-					"(?i)(((video|buffer|play|stuck|work|time|freeze|infinite|1:09|endless|\\sload).*){2,})"
+					"(?i)(((video|buffer|stops play|stuck|time |freeze|infinite|1:09|endless|\\sload).*){2,})"
 				]
 			},
 			"excludes": {


### PR DESCRIPTION
reduces false positives, especially important because this match will close support threads; times does no longer get matched;
work was too universal
play has been changed to be more specific